### PR TITLE
Speedup settings for CI server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
-  - composer self-update
-  - composer install --no-interaction --prefer-source --dev
+  - composer install --no-interaction --prefer-source
 
 script:
   - ./vendor/bin/parallel-lint --exclude vendor .


### PR DESCRIPTION
- update Composer is not necessary in CI server
- --dev is default konfiguration in Composer
