### PR TITLE
Add the Symfony Vardumper dd() helper method introduced in 4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Options for run
 - `--tracy` - check dump: `dump`, `bdump`, `Debugger::dump`, `Debugger::barDump`
 - `--zend` - check dump: `Zend_Debug::dump`, `\Zend\Debug\Debug::dump`
 - `--doctrine` - check dump: `Doctrine::dump`, `\Doctrine\Common\Util\Debug::dump`
-- `--symfony` - check dump: `dump`, `VarDumper::dump`, `VarDumper::setHandler`
+- `--symfony` - check dump: `dump`, `VarDumper::dump`, `VarDumper::setHandler`, `VarDumper::dd`
 - `--laravel` - check dump: `dd`
 - `--no-colors` - disable colors from output
 - `--exclude folder/` - exclude *folder/* from check

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -23,6 +23,8 @@ class Settings
         SYMFONY_VARDUMPER_HANDLER = 'VarDumper::setHandler',
         SYMFONY_VARDUMPER_DUMP = 'VarDumper::dump',
         SYMFONY_VARDUMPER_DUMP_SHORTCUT = 'dump',
+        SYMFONY_VARDUMPER_DD = 'VarDumper::dd',
+        SYMFONY_VARDUMPER_DD_SHORTCUT = 'dd',
 
         LARAVEL_DUMP_DD = 'dd',
 
@@ -111,6 +113,8 @@ class Settings
                     case '--symfony':
                         $setting->functionsToCheck[] = self::SYMFONY_VARDUMPER_DUMP;
                         $setting->functionsToCheck[] = self::SYMFONY_VARDUMPER_DUMP_SHORTCUT;
+                        $setting->functionsToCheck[] = self::SYMFONY_VARDUMPER_DD;
+                        $setting->functionsToCheck[] = self::SYMFONY_VARDUMPER_DD_SHORTCUT;
                         $setting->functionsToCheck[] = self::SYMFONY_VARDUMPER_HANDLER;
                         break;
 

--- a/tests/JakubOnderka/PhpVarDumpCheck/SymfonyTest.php
+++ b/tests/JakubOnderka/PhpVarDumpCheck/SymfonyTest.php
@@ -14,6 +14,8 @@ class SymfonyTest extends PHPUnit_Framework_TestCase
             PhpVarDumpCheck\Settings::SYMFONY_VARDUMPER_HANDLER,
             PhpVarDumpCheck\Settings::SYMFONY_VARDUMPER_DUMP,
             PhpVarDumpCheck\Settings::SYMFONY_VARDUMPER_DUMP_SHORTCUT,
+            PhpVarDumpCheck\Settings::SYMFONY_VARDUMPER_DD,
+            PhpVarDumpCheck\Settings::SYMFONY_VARDUMPER_DD_SHORTCUT,
         ));
         $this->uut = new PhpVarDumpCheck\Checker($settings);
     }
@@ -28,6 +30,17 @@ PHP;
         $result = $this->uut->check($content);
         $this->assertCount(1, $result);
     }
+
+    public function testCheck_symfonyDD()
+    {
+        $content = <<<PHP
+<?php
+VarDumper::dd(\$var);
+PHP;
+        $result = $this->uut->check($content);
+        $this->assertCount(1, $result);
+    }
+
 
     public function testCheck_symfonyDebugSetHandler()
     {
@@ -63,18 +76,31 @@ PHP;
     }
 
 
+    public function testCheck_symfonyDDShortcut()
+    {
+        $content = <<<PHP
+<?php
+dd(\$var);
+PHP;
+        $result = $this->uut->check($content);
+        $this->assertCount(1, $result);
+    }
+
+
     public function testCheck_symfonyDumpsWithNamespace()
     {
         $content = <<<PHP
 <?php
 \\dump(\$var);
 \\Symfony\\Component\\VarDumper\\VarDumper::dump(\$var);
+\\dd(\$var);
+\\Symfony\\Component\\VarDumper\\VarDumper::dd(\$var);
 \\Symfony\\Component\\VarDumper\\VarDumper::setHandler(\$var);
 \\Symfony\\Component\\VarDumper\\VarDumper::setHandler(function(){
 
 });
 PHP;
         $result = $this->uut->check($content);
-        $this->assertCount(4, $result);
+        $this->assertCount(6, $result);
     }
 }

--- a/var-dump-check.php
+++ b/var-dump-check.php
@@ -18,7 +18,7 @@ Options:
     --tracy       Enable support for Tracy (Debugger::dump)
     --zend        Enable support for Zend (Zend_Debug::dump and \Zend\Debug\Debug::dump)
     --ladybug     Enable support for Ladybug (ladybug_dump, ladybug_dump_die, ld, ldd)
-    --symfony     Enable support for Symfony2 (dump, VarDumper::dump, VarDumper::setHandler)
+    --symfony     Enable support for Symfony2 (dump, VarDumper::dump, VarDumper::setHandler, Vardumper::dd())
     --doctrine    Enable support for Doctrine (Doctrine::dump, \Doctrine\Common\Util\Debug::dump)
     --laravel     Enable support for Laravel (dd, dump)
     --extensions  Check only files with selected extensions separated by comma


### PR DESCRIPTION
https://symfony.com/doc/current/components/var_dumper.html#the-dump-function

> The VarDumper component also provides a dd() ("dump and die") helper function. This function dumps the variables using dump() and immediately ends the execution of the script (using exit).
> New in version 4.1: The dd() helper method was introduced in Symfony 4.1.
