### PR TITLE
Add laravel dump helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Options for run
 - `--zend` - check dump: `Zend_Debug::dump`, `\Zend\Debug\Debug::dump`
 - `--doctrine` - check dump: `Doctrine::dump`, `\Doctrine\Common\Util\Debug::dump`
 - `--symfony` - check dump: `dump`, `VarDumper::dump`, `VarDumper::setHandler`
-- `--laravel` - check dump: `dd`
+- `--laravel` - check dump: `dd`, `dump`
 - `--no-colors` - disable colors from output
 - `--exclude folder/` - exclude *folder/* from check
 - `--extensions php,phpt,php7` - map file extensions for check

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -25,6 +25,7 @@ class Settings
         SYMFONY_VARDUMPER_DUMP_SHORTCUT = 'dump',
 
         LARAVEL_DUMP_DD = 'dd',
+        LARAVEL_DUMP = 'dump',
 
         DOCTRINE_DUMP = 'Doctrine::dump',
         DOCTRINE_DUMP_2 = '\Doctrine\Common\Util\Debug::dump';
@@ -116,6 +117,7 @@ class Settings
 
                     case '--laravel':
                         $setting->functionsToCheck[] = self::LARAVEL_DUMP_DD;
+                        $setting->functionsToCheck[] = self::LARAVEL_DUMP;
                         break;
 
                     case '--doctrine':

--- a/tests/JakubOnderka/PhpVarDumpCheck/LaravelTest.php
+++ b/tests/JakubOnderka/PhpVarDumpCheck/LaravelTest.php
@@ -12,6 +12,7 @@ class LaravelTest extends PHPUnit_Framework_TestCase
         $settings = new PhpVarDumpCheck\Settings();
         $settings->functionsToCheck = array_merge($settings->functionsToCheck, array(
             PhpVarDumpCheck\Settings::LARAVEL_DUMP_DD,
+            PhpVarDumpCheck\Settings::LARAVEL_DUMP,
         ));
         $this->uut = new PhpVarDumpCheck\Checker($settings);
     }
@@ -22,6 +23,16 @@ class LaravelTest extends PHPUnit_Framework_TestCase
         $content = <<<PHP
 <?php
 dd(\$var);
+PHP;
+        $result = $this->uut->check($content);
+        $this->assertCount(1, $result);
+    }
+
+    public function testCheck_laravelDump()
+    {
+        $content = <<<PHP
+<?php
+dump(\$var);
 PHP;
         $result = $this->uut->check($content);
         $this->assertCount(1, $result);


### PR DESCRIPTION
Adds laravel `dump` helper method as one of the checks performed during the laravel preset.

Resolves #29 