### PR TITLE
handle comments as white space

### DIFF
--- a/src/Checker.php
+++ b/src/Checker.php
@@ -171,7 +171,7 @@ class Checker
     {
         $tokens = token_get_all($content);
         $tokens = array_values(array_filter($tokens, function ($token) {
-            return !is_array($token) || $token[0] !== T_WHITESPACE;
+            return !is_array($token) || !in_array($token[0], [T_WHITESPACE, T_COMMENT]);
         }));
 
         return $tokens;

--- a/tests/JakubOnderka/PhpVarDumpCheck/CheckTest.php
+++ b/tests/JakubOnderka/PhpVarDumpCheck/CheckTest.php
@@ -38,6 +38,19 @@ PHP;
         $this->assertEquals(2, $result[0]->getLineNumber());
     }
 
+    public function testCheck_singleVarDump_after_comments()
+    {
+        $content = <<<PHP
+<?php
+// some comment
+var_dump('Ahoj');
+PHP;
+        $result = $this->uut->check($content);
+        $this->assertCount(1, $result);
+        $this->assertEquals('var_dump', $result[0]->getType());
+        $this->assertTrue($result[0]->isSure());
+        $this->assertEquals(3, $result[0]->getLineNumber());
+    }
 
     public function testCheck_singlePrintR_dump()
     {


### PR DESCRIPTION
the script didn't detect `var_dump()` if the previous token was a comment